### PR TITLE
allow to use dcmdjpeg instead of gdcmconv

### DIFF
--- a/dicom2nifti/compressed_dicom.py
+++ b/dicom2nifti/compressed_dicom.py
@@ -61,6 +61,23 @@ def _get_gdcmconv():
     return gdcmconv_executable
 
 
+def _get_dcmdjpeg():
+    """
+    Get the full path to gdcmconv.
+    If not found raise error
+    """
+    dcmdjpeg_executable = settings.dcmdjpeg_path
+    if dcmdjpeg_executable is None:
+        dcmdjpeg_executable = _which('dcmdjpeg')
+    if dcmdjpeg_executable is None:
+        dcmdjpeg_executable = _which('dcmdjpeg.exe')
+
+    if dcmdjpeg_executable is None:
+        raise ConversionError('DCMDJPEG_NOT_FOUND')
+
+    return dcmdjpeg_executable
+
+
 def compress_directory(dicom_directory):
     """
     This function can be used to convert a folder of jpeg compressed images to an uncompressed ones
@@ -128,9 +145,12 @@ def _decompress_dicom(dicom_file, output_file):
 
     :param input_file: single dicom file to decompress
     """
-    gdcmconv_executable = _get_gdcmconv()
-
-    subprocess.check_output([gdcmconv_executable, '-w', dicom_file, output_file])
+    try:
+        dcmdjpeg_executable = _get_dcmdjpeg()
+        subprocess.check_output([dcmdjpeg_executable, dicom_file, output_file])
+    except ConversionError:
+        gdcmconv_executable = _get_gdcmconv()
+        subprocess.check_output([gdcmconv_executable, '-w', dicom_file, output_file])
 
 
 def _which(program):

--- a/dicom2nifti/settings.py
+++ b/dicom2nifti/settings.py
@@ -6,6 +6,7 @@ validate_slice_increment = True
 validate_multiframe_implicit = True
 pydicom_read_force = False
 gdcmconv_path = None
+dcmdjpeg_path = None
 resample = False
 resample_padding = 0
 resample_spline_interpolation_order = 0  # spline interpolation order (0 nn , 1 bilinear, 3 cubic)
@@ -157,3 +158,13 @@ def set_gdcmconv_path(path):
     """
     global gdcmconv_path
     gdcmconv_path = path
+
+
+def set_dcmdjpeg_path(path):
+    """
+    Set where the filepath to the dcmdjpeg executable (needed is it is not found in your PATH)
+
+    :param path: the file path to the dcmdjpeg executable
+    """
+    global dcmdjpeg_path
+    dcmdjpeg_path = path


### PR DESCRIPTION
Hi,

what do you think about that? Seems to work for me.
On some systems it is easier to install dcmtk than gdcm (e.g. MacOS 10.11.6 where homebrew needs a full XCode installation to compile gdcm)