### PR TITLE
fix command line option inconsistent_slice_thickness

### DIFF
--- a/scripts/dicom2nifti
+++ b/scripts/dicom2nifti
@@ -68,6 +68,8 @@ def main(args):
     else:
         if args.allow_gantry_tilting:
             settings.disable_validate_orthogonal()
+        if args.allow_inconsistent_slice_increment:
+            settings.disable_validate_slice_increment()
         if args.allow_multiframe_implicit:
             settings.disable_validate_multiframe_implicit()
         if args.allow_single_slice:


### PR DESCRIPTION
Please accept this bug fix, because otherwise I cannot use the command line for dicom2nifti
This is minimal risk, and will not cause any incompatibilities