### PR TITLE
Writing output_file as optional in reorient_image

### DIFF
--- a/dicom2nifti/image_reorientation.py
+++ b/dicom2nifti/image_reorientation.py
@@ -12,7 +12,7 @@ import numpy
 from dicom2nifti.image_volume import load, SliceType, ImageVolume
 
 
-def reorient_image(input_image, output_image):
+def reorient_image(input_image, output_image=None):
     """
     Change the orientation of the Image data in order to be in LAS space
     x will represent the coronal plane, y the sagittal and z the axial plane.
@@ -82,7 +82,8 @@ def reorient_image(input_image, output_image):
     output = nibabel.nifti1.Nifti1Image(new_image, new_affine)
     output.header.set_slope_inter(1, 0)
     output.header.set_xyzt_units(2)  # set units for xyz (leave t as unknown)
-    output.to_filename(output_image)
+    if output_image is not None:
+        output.to_filename(output_image)
     return output
 
 


### PR DESCRIPTION
Relates to issue #33

**Problem:**   
If I try to do something like `nii = dicom2nifti.dicom_series_to_nifti(dcm_path, output_file=None)`, I'll get a `ImageFileError: Filespec "None" does not look right for class <class 'nibabel.nifti1.Nifti1Image'>` error (for the complete error, see below).

**Solution:**  
The error comes from the lack of a simple check in the `dicom2nifti.image_reorientation.reorient_image` function.  
The provided solution adds this simple check wheather to overwrite the `output_file`.



_**Full error:**_

---------------------------------------------------------------------------
TypesFilenamesError                       Traceback (most recent call last)
File ~/miniconda3/envs/brain/lib/python3.8/site-packages/nibabel/filebasedimages.py:299, in FileBasedImage.filespec_to_file_map(klass, filespec)
    298 try:
--> 299     filenames = types_filenames(
    300         filespec, klass.files_types,
    301         trailing_suffixes=klass._compressed_suffixes)
    302 except TypesFilenamesError:

File ~/miniconda3/envs/brain/lib/python3.8/site-packages/nibabel/filename_parser.py:114, in types_filenames(template_fname, types_exts, trailing_suffixes, enforce_extensions, match_case)
    113 if not isinstance(template_fname, str):
--> 114     raise TypesFilenamesError('Need file name as input '
    115                               'to set_filenames')
    116 if template_fname.endswith('.'):

TypesFilenamesError: Need file name as input to set_filenames

During handling of the above exception, another exception occurred:

ImageFileError                            Traceback (most recent call last)
Input In [16], in <cell line: 1>()
----> 1 nii["NII"].to_filename(None)

File ~/miniconda3/envs/brain/lib/python3.8/site-packages/nibabel/filebasedimages.py:332, in FileBasedImage.to_filename(self, filename)
    318 def to_filename(self, filename):
    319     """ Write image to files implied by filename string
    320 
    321     Parameters
   (...)
    330     None
    331     """
--> 332     self.file_map = self.filespec_to_file_map(filename)
    333     self.to_file_map()

File ~/miniconda3/envs/brain/lib/python3.8/site-packages/nibabel/filebasedimages.py:303, in FileBasedImage.filespec_to_file_map(klass, filespec)
    299     filenames = types_filenames(
    300         filespec, klass.files_types,
    301         trailing_suffixes=klass._compressed_suffixes)
    302 except TypesFilenamesError:
--> 303     raise ImageFileError(
    304         f'Filespec "{filespec}" does not look right for class {klass}')
    305 file_map = {}
    306 for key, fname in filenames.items():

ImageFileError: Filespec "None" does not look right for class <class 'nibabel.nifti1.Nifti1Image'>
