### PR TITLE
fix overflow error

### DIFF
--- a/dicom2nifti/common.py
+++ b/dicom2nifti/common.py
@@ -544,7 +544,7 @@ def do_scaling(data, rescale_slope, rescale_intercept, private_scale_slope=1.0, 
         # Determine required datatype from that
         if minimum_required < 0:
             # Signed integer type
-            maximum_required = max([-minimum_required, maximum_required])
+            maximum_required = max([-(minimum_required + 1), maximum_required])
             if maximum_required < 2 ** 7:
                 dtype = numpy.int8
             elif maximum_required < 2 ** 15:


### PR DESCRIPTION
An error was encountered when converting certain DICOM files from a publicly available dataset from the https://www.gaain.org/centiloid-project website.

Specifically, when converting DICOMs of some patients MRIs from the YC group (https://www.gaaindata.org/data/centiloid/YC-0_MR.zip - for instance patient YC101), an overflow warning is encountered:

  dicom2nifti/common.py:548: RuntimeWarning: overflow encountered in scalar negative
      maximum_required = max([-minimum_required, maximum_required])

The resulting NIFTI file is corrupted, as some background values overflowed and have values around the 2^15 (32k) range.

The problem appears only when the converted DICOM pixel array includes values precisely at the lower limit of the signed 16 bit integer (int16) value range, which is [-32768, 32767]. When performing the operation -(-32768), the int16 overflows.

The proposed solution ensures that the operation _"-minimum_required"_ never encounters the overflow warning by adding +1.

How the converted NIFTI file of the YC101 MRI looks like in 3D Slicer, together with image histogram, before the fix:
![image](https://github.com/icometrix/dicom2nifti/assets/73024775/5e54a1d1-89ad-471d-9881-78bb1e9d9ee4)

How the converted NIFTI looks like after the fix:
![image (1)](https://github.com/icometrix/dicom2nifti/assets/73024775/813bacba-e00d-45b3-a864-8a6622de4b46)
