### PR TITLE
Handle type errors when checking "is_float"

### DIFF
--- a/dicom2nifti/common.py
+++ b/dicom2nifti/common.py
@@ -1095,10 +1095,14 @@ def set_tr_te(nifti_image, repetition_time, echo_time):
         """
         Helper to check if something is a float
         """
+        if number is None:
+            return False
         try:
             float(number)
             return True
         except ValueError:
+            return False
+        except TypeError:
             return False
 
     # only set if it is an actual float, can also be empty/none

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 from setuptools import find_packages
 
 
-version = "2.6.0"
+version = "2.6.0.nonefix"
 print('Starting pypi release version %s' % version)
 long_description = """
 With this package you can convert dicom images to nifti files.


### PR DESCRIPTION
Fix a bug: When `number` is None, an uncatched exception `TypeError` may occur. 

This happened for the TCGA-GBM dataset:
https://www.cancerimagingarchive.net/collection/tcga-gbm/
where "echo time" and "repetition time" are None's.